### PR TITLE
Meta link for atom feed discovery

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,6 +16,8 @@
    <link rel="stylesheet" href="/css/screen.css" type="text/css" 
 	 media="screen, projection" />
 
+   <link rel="alternate" type="application/atom+xml" title="Joe Armstrong's blog"
+         href="/feed.xml">
  </head>
 <body>
 


### PR DESCRIPTION
Mr. Armstrong, please consider adding the meta link to allow browser discover it and show the icon to subscribe
