### PR TITLE
Corrected 'illegal pattern' syntax error.

### DIFF
--- a/_posts/2013-11-21-My-favorite-erlang-program.md
+++ b/_posts/2013-11-21-My-favorite-erlang-program.md
@@ -48,7 +48,7 @@ factorial of an integer. This is mind-boggling simple:
 {% highlight erlang %}
 factorial_server() ->
     receive
-       {From ! N} ->
+       {From, N} ->
            From ! factorial(N),
            factorial_server()
     end.


### PR DESCRIPTION
Replaced a "!" with a "," to correct "illegal pattern" 

```
$ erlc demo1.erl
demo1.erl:13: 
demo1.erl:13: illegal pattern
demo1.erl:14: variable 'From' is unbound
demo1.erl:14: variable 'N' is unbound
```

Complete corrected sample: https://gist.github.com/bryanhunter/7994399
