### PR TITLE
Configure syntax highlighting

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 markdown: rdiscount
-highlighter: true
+highlighter: pygments
 rdiscount:
   extensions: [smart, autolink]
 


### PR DESCRIPTION
The `highlighter: true` setting has been deprecated and now supports
either `rouge` or `pygments` as allowed values.

http://jekyllrb.com/docs/templates/#code-snippet-highlighting

If you prefer one over the other, I'd be happy to modify this PR.

In order for this to work locally, you will need to have the `pygments` gem installed.
