### PR TITLE
fix mixedcontent, updated http -> https where possible

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,5 +12,4 @@ comments :
 
 name: Joe Armstrong's blog
 description: Joe Armstrong's Erlang and other stuff blog
-url: http://joearms.github.com
-
+url: https://joearms.github.com

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -74,8 +74,8 @@
 	  Source code <a href="https://github.com/joearms/joearms.github.com">here</a>.
 	</p>
 	<p>
-	  joearms@gmail.com <a href="http://github.com/joearms/">github.com/joearms</a>
-	  <a href="http://twitter.com/joeerl/">twitter.com/joeerl</a>
+	  joearms@gmail.com <a href="https://github.com/joearms/">github.com/joearms</a>
+	  <a href="https://twitter.com/joeerl/">twitter.com/joeerl</a>
 	</p>
       </div>
     </div>

--- a/_layouts/default_2.html
+++ b/_layouts/default_2.html
@@ -4,11 +4,9 @@
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
     <meta name="author" content="Joe Armstrong" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    
-    <title>{{page.title}}</title>
-    
 
-    
+    <title>{{page.title}}</title>
+
     <!-- Bootstrap -->
     <link href="/css/bootstrap.min.css" rel="stylesheet" media="screen" />
     <link href="/css/bootstrap-responsive.min.css" rel="stylesheet" />
@@ -16,73 +14,72 @@
     <link rel="stylesheet" href="/css/syntax.css" type="text/css" />
     <!-- RSS -->
     <link rel="alternate" type="application/rss+xml" title="RSS" href="/feed.xml" />
-    <link rel="stylesheet" href="/css/screen.css" type="text/css" 
-	  media="screen, projection" />
+    <link rel="stylesheet" href="/css/screen.css" type="text/css" media="screen, projection" />
   </head>
 
   <body>
     <div class="navbar">
       <div class="navbar-inner">
-	<a class="brand" href="/index.html">Joe Armstrong - Erlang and other stuff</a>
-	<ul class="nav">
-	  <li><a href="/index.html">Home</a></li>
-	  <li><a href="/archive.html">Archive</a></li>
-	  <li><a href="/resources.html">Resources</a></li>
-	  <li><a href="/installing.html">Installing</a></li>
-	  <li><a href="/links.html">Links</a></li>
-	  <li><a href="https://github.com/joearms/joearms.github.com/">Source</a></li>
-	</ul>
+    <a class="brand" href="/index.html">Joe Armstrong - Erlang and other stuff</a>
+    <ul class="nav">
+      <li><a href="/index.html">Home</a></li>
+      <li><a href="/archive.html">Archive</a></li>
+      <li><a href="/resources.html">Resources</a></li>
+      <li><a href="/installing.html">Installing</a></li>
+      <li><a href="/links.html">Links</a></li>
+      <li><a href="https://github.com/joearms/joearms.github.com/">Source</a></li>
+    </ul>
       </div>
     </div>
-    
+
     <div class="customize">
       <div class="row-fluid">
-	<div class="span7 offset1">
-	  <p>
-	    <a href="https://twitter.com/joeerl" class="twitter-follow-button" 
-	       data-show-count="false" data-show-screen-name="false">Follow</a>
-	    <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
-	  </p>
- 
-	  {{content}}
-	</div>
-	<div class="span3">
-	  <h2>Books</h2>
-	  <p>
-	    <img src="/images/jaerlang2_small.jpg" alt="Programming Erlang book"/>
-	    <br/>
-	    <a href="http://pragprog.com/book/jaerlang2/programming-erlang">
-	    Programming Erlang</a>
-	  </p>
-	  
-	  <p>
-	    <img src="/images/joe_thesis.jpg" alt="joe thesis"/><br/>
-	    <b>Making Reliable Distributed Systems in the Presence of software errors</b>
-	    <a href="http://www.sics.se/~joe/thesis/armstrong_thesis_2003.pdf">download</a>
-	  </p>
-	</div>
+    <div class="span7 offset1">
+      <p>
+        <a href="https://twitter.com/joeerl" class="twitter-follow-button"
+           data-show-count="false" data-show-screen-name="false">Follow</a>
+        <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
+      </p>
+
+      {{content}}
+    </div>
+    <div class="span3">
+      <h2>Books</h2>
+      <p>
+        <img src="/images/jaerlang2_small.jpg" alt="Programming Erlang book"/>
+        <br/>
+        <a href="https://pragprog.com/book/jaerlang2/programming-erlang">
+        Programming Erlang</a>
+      </p>
+
+      <p>
+        <img src="/images/joe_thesis.jpg" alt="joe thesis"/><br/>
+        <b>Making Reliable Distributed Systems in the Presence of software errors</b>
+        <a href="http://www.sics.se/~joe/thesis/armstrong_thesis_2003.pdf">download</a>
+      </p>
+    </div>
       </div>
     </div>
-    
+
     <!-- Footer  ==================================== -->
     <footer class="footer">
       <div class="container">
-	<p>&copy; 2013 Joe Armstrong</p>
-	  Theme and code from <a href="https://github.com/mojombo">Tom
-	  Preston-Werner</a>.<br /> Hosted by <a
-	  href="https://github.com/networc/networc.github.com/">GitHub</a>
-	  and powered by <a
-	  href="https://github.com/mojombo/jekyll">Jekyll</a>.
-	  Source code <a href="https://github.com/joearms/joearms.github.com">here</a>.
-	</p>
-	<p>
-	  joearms@gmail.com <a href="http://github.com/joearms/">github.com/joearms</a>
-	  <a href="http://twitter.com/joeerl/">twitter.com/joeerl</a>
-	</p>
+    <p>&copy; 2013 Joe Armstrong</p>
+      Theme and code from <a href="https://github.com/mojombo">Tom
+      Preston-Werner</a>.<br /> Hosted by <a
+      href="https://github.com/networc/networc.github.com/">GitHub</a>
+      and powered by <a
+      href="https://github.com/mojombo/jekyll">Jekyll</a>.
+      Source code <a href="https://github.com/joearms/joearms.github.com">here</a>.
+    </p>
+    <p>
+      joearms@gmail.com <a href="https://github.com/joearms/">github.com/joearms</a>
+      <a href="https://twitter.com/joeerl/">twitter.com/joeerl</a>
+    </p>
       </div>
     </footer>
 
-    <script src="http://code.jquery.com/jquery-latest.min.js"></script>
+    <script src="https://code.jquery.com/jquery-latest.min.js"></script>
     <script src="/js/bootstrap.min.js"></script>
     <!-- Google Analytics -->
     <script>
@@ -90,7 +87,7 @@
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
       m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-      
+
       ga('create', 'UA-39670657-1', 'github.com');
       ga('send', 'pageview');
     </script>

--- a/_layouts/default_3.html
+++ b/_layouts/default_3.html
@@ -56,13 +56,13 @@
 	  Source code <a href="https://github.com/joearms/joearms.github.com">here</a>.
 	</p>
 	<p>
-	  joearms@gmail.com <a href="http://github.com/joearms/">github.com/joearms</a>
-	  <a href="http://twitter.com/joeerl/">twitter.com/joeerl</a>
+	  joearms@gmail.com <a href="https://github.com/joearms/">github.com/joearms</a>
+	  <a href="https://twitter.com/joeerl/">twitter.com/joeerl</a>
 	</p>
       </div>
     </footer>
 
-    <script src="http://code.jquery.com/jquery-latest.min.js"></script>
+    <script src="https://code.jquery.com/jquery-latest.min.js"></script>
     <script src="/js/bootstrap.min.js"></script>
 
     <!-- Google Analytics -->

--- a/_posts/2013-04-28-Fail-fast-noisely-and-politely.md
+++ b/_posts/2013-04-28-Fail-fast-noisely-and-politely.md
@@ -8,7 +8,7 @@ day: 23
 published: true
 ---
 
-In [Programming Erlang 2'nd edition](http://pragprog.com/book/jaerlang2/programming-erlang)
+In [Programming Erlang 2'nd edition](https://pragprog.com/book/jaerlang2/programming-erlang)
 I described a new design principle.
 
 When applications fail, the programmer should provide **two** error

--- a/_posts/2013-05-31-a-week-with-elixir.md
+++ b/_posts/2013-05-31-a-week-with-elixir.md
@@ -12,7 +12,7 @@ in any detail.
 
 This all changed when I discovered the announcement that Dave Thomas
 was publishing [Programming
-Elixir](http://pragprog.com/book/elixir/programming-elixir).  Dave
+Elixir](https://pragprog.com/book/elixir/programming-elixir).  Dave
 Thomas edited my Erlang book and did great work in introducing Ruby,
 so when Dave gets excited about something then this is a sure sign
 that something interesting is in the wind.

--- a/resources.md
+++ b/resources.md
@@ -8,7 +8,7 @@ just a placeholder. I've started to add some information here.
 
 Books
 =====
-* [Programming Erlang 2'nd edition](http://pragprog.com/book/jaerlang2/programming-erlang)
+* [Programming Erlang 2'nd edition](https://pragprog.com/book/jaerlang2/programming-erlang)
 * [Erlang Programming](http://shop.oreilly.com/product/9780596518189.do)
 * [Learn you some Erlang for great good](http://learnyousomeerlang.com/)
 * [Introducing Erlang](http://shop.oreilly.com/product/0636920025818.do)


### PR DESCRIPTION
Since Github allows https on Github Pages there's no reason to use http over https.

This PR fixes mixedcontent warnings that happen because of scripts attempting to load over http while the page is loaded on https such as JQuery, the Twitter embed script and Disqus comments script. I've also updated a few other links to goto the https version instead of http since they support it.
