### PR TITLE
Fixed typos in "Managing two million webservers" post

### DIFF
--- a/_posts/2016-03-13-Managing-two-million-webservers.md
+++ b/_posts/2016-03-13-Managing-two-million-webservers.md
@@ -20,7 +20,7 @@ by Chris McCord and Evan Czaplicki at the [2016 Erlang Factory in San
 Francisco](http://www.erlang-factory.com/sfbay2016).
 
 Imagine an Erlang or Elixir HTTP server managing a couple of million
-user sessions.  Time and again I've heard this said:
+user sessions. Time and again I've heard this said:
 
 + We have a (Erlang or Elixir) web server managing 2 million user sessions.
 
@@ -81,7 +81,7 @@ they don't pack well and much space is wasted.
 
 # Adding fault-tolerance and scalability
 
-> Because we have one web server per user  we can easily make the
+> Because we have one web server per user we can easily make the
 system fault tolerant or scalable
 
 To make a fault tolerant system we use two or more processes per user;
@@ -90,18 +90,3 @@ machines. They must be on different machines since the entire machine
 where the master runs might crash. We can make it scalable  by just
 buying more machines and spreading the processes out over the
 machines.
- 
-
-
-
-
-
-
-
-
-
-
-
-
-  
-

--- a/_posts/2016-03-13-Managing-two-million-webservers.md
+++ b/_posts/2016-03-13-Managing-two-million-webservers.md
@@ -73,7 +73,7 @@ outperform Ruby on Rails? - precisely because we have millions of tiny
 webservers - and when we have lots of small things it's easy to spread
 them over lots of processors and make the system fault-tolerant and scalable.
 
-Packing Erlang or Elixir processes onto cores is easy becuase they are
+Packing Erlang or Elixir processes onto cores is easy because they are
 small and are like packing physical objects. If we want to pack sand
 in barrels it's easy. The grains of sand are so small that it's easy
 to completely fill the barrels. Backing huge boulders is difficult,
@@ -84,7 +84,7 @@ they don't pack well and much space is wasted.
 > Because we have one web server per user  we can easily make the
 system fault tolerant or scalable
 
-To make a fault tolerent system we use two or more processes per user;
+To make a fault tolerant system we use two or more processes per user;
 One is the master process, the others are replicas on different
 machines. They must be on different machines since the entire machine
 where the master runs might crash. We can make it scalable  by just


### PR DESCRIPTION
:information_desk_person: These changes fix spelling typos and errant spacing in the "Managing two-million webservers" post (which I greatly enjoyed :gift_heart:).
