### PR TITLE
fix typo "figures" to "fingers"

### DIFF
--- a/2016/03/13/Calling-Elixir-From_Erlang.html
+++ b/2016/03/13/Calling-Elixir-From_Erlang.html
@@ -97,7 +97,7 @@ io:format("Elixir paths set~n").
    X = 'Elixir.File':'read!'("module.ex"),
    Ast = 'Elixir.Code':string_to_quoted(X).
 </div>
-<p>Keeping my figures crossed I ran this in the Erlang shell:
+<p>Keeping my fingers crossed I ran this in the Erlang shell:
 </p>
 <div class='pre'>> test:test().
 ** exception error: bad argument


### PR DESCRIPTION
"figures crossed" should be "fingers crossed"